### PR TITLE
Fix mysql problems

### DIFF
--- a/next/Dockerfile
+++ b/next/Dockerfile
@@ -2,7 +2,7 @@
 #
 # VERSION 0.0.2
 
-FROM ubuntu:14.04
+FROM phusion/baseimage:0.9.10
 MAINTAINER Yoan Blanc <yoan.blanc@cern.ch>
 
 ENV DEBIAN_FRONTEND noninteractive
@@ -70,4 +70,5 @@ EXPOSE 4000
 
 VOLUME /var/lib/mysql
 VOLUME /home/$USER/.virtualenvs
-CMD ["/usr/bin/supervisord"]
+RUN echo "source /usr/local/bin/virtualenvwrapper.sh" >> ~/.bashrc
+CMD supervisord

--- a/next/README.md
+++ b/next/README.md
@@ -26,9 +26,8 @@ it to your usage beforehand.
 
 Once everything is installed, you may run invenio.
 
-    $ workon pu
-    (pu) $ cdvirtualenv src/invenio
-    (pu) $ inveniomanage runserver
+    $ workon next
+    (next) $ inveniomanage runserver
 
 To quit, I would recommend you to stop the processes from supervisord instead
 of relying on docker. MySQL can be a bit slow to stop.

--- a/next/setup-mysql.sh
+++ b/next/setup-mysql.sh
@@ -23,4 +23,4 @@ mysqladmin -u root password ''
 mysql -u root -e "CREATE USER 'admin'@'%' IDENTIFIED BY '${MYSQL_PASS}'"
 mysql -u root -e "GRANT ALL PRIVILEGES ON *.* TO 'admin'@'%' WITH GRANT OPTION"
 
-mysqladmin -u root shutdown
+service mysql stop

--- a/next/setup.sh
+++ b/next/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Variables to configure
-VIRTUALENV_NAME=pu
+VIRTUALENV_NAME=next
 PACKAGE=invenio_demosite
 #PACKAGE=cds
 PORT=4000
@@ -67,7 +67,7 @@ if [ -e package.json ]; then
     npm install
 fi
 if [ -e bower.json ]; then
-    bower install
+    bower install --allow-root
 fi
 if [ -e Gruntfile.js ]; then
     grunt || die 1 "grunt failed"
@@ -87,7 +87,7 @@ if [ -e package.json ]; then
     npm install
 fi
 if [ -e bower.json ]; then
-    bower install
+    bower install --allow-root
 fi
 if [ -e Gruntfile.js ]; then
     grunt || die 1 "grunt failed"
@@ -98,7 +98,7 @@ cdvirtualenv
 
 inveniomanage config create secret-key
 inveniomanage config set CFG_EMAIL_BACKEND flask.ext.email.backends.console.Mail
-inveniomanage config set CFG_BIBSCHED_PROCESS_USER ${USER}
+inveniomanage config set CFG_BIBSCHED_PROCESS_USER root
 inveniomanage config set CFG_DATABASE_NAME invenio
 inveniomanage config set CFG_DATABASE_USER invenio
 inveniomanage config set CFG_SITE_URL http://0.0.0.0:${PORT}
@@ -125,6 +125,8 @@ inveniomanage config set COLLECT_STORAGE invenio.ext.collect.storage.link
 cdvirtualenv
 
 inveniomanage collect
+
+supervisord &
 
 inveniomanage database init --yes-i-know --user=root
 inveniomanage database create

--- a/next/setup.sh
+++ b/next/setup.sh
@@ -98,7 +98,7 @@ cdvirtualenv
 
 inveniomanage config create secret-key
 inveniomanage config set CFG_EMAIL_BACKEND flask.ext.email.backends.console.Mail
-inveniomanage config set CFG_BIBSCHED_PROCESS_USER root
+inveniomanage config set CFG_BIBSCHED_PROCESS_USER ${USER}
 inveniomanage config set CFG_DATABASE_NAME invenio
 inveniomanage config set CFG_DATABASE_USER invenio
 inveniomanage config set CFG_SITE_URL http://0.0.0.0:${PORT}
@@ -125,8 +125,6 @@ inveniomanage config set COLLECT_STORAGE invenio.ext.collect.storage.link
 cdvirtualenv
 
 inveniomanage collect
-
-supervisord &
 
 inveniomanage database init --yes-i-know --user=root
 inveniomanage database create


### PR DESCRIPTION
Using `ubuntu:14.04` as a base made mysql fail to start (unable to obtain write rights) for me. Solved with basing from `phusion/baseimage:0.9.10` (see [details](http://phusion.github.io/baseimage-docker/)). 
Aside from that, needed to additionally run `supervisord` before populating the database, since it didn't automatically start with the container for some reason.
Also bower doesn't install packages under root, hence adding `--allow-root' option for this case.
The rest are minor changes.
